### PR TITLE
added rule for INI first_line equal to #ini

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -156,7 +156,8 @@
             "extensions": [".gitattributes", ".gitconfig", ".gitignore", "ini.dist", ".npmrc"],
             "rules": [
                 {"file_path": ".*/git/(attributes|config|ignore)$"},
-                {"file_path": ".*\\\\git\\\\(attributes|config|ignore)$"}
+                {"file_path": ".*\\\\git\\\\(attributes|config|ignore)$"},
+                {"first_line": "#ini"}
             ]
         },
         {


### PR DESCRIPTION
for ini files that aren't named .ini, this change allows you to put #ini in the first line of the file to have it detected as an ini file
